### PR TITLE
MQTT host IP is a variable now.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,6 +29,7 @@ import paho.mqtt.client as mqtt
 os.chdir(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
 
 # Various constants
+mqtt_ip = "127.0.0.1"
 # noinspection PyTypeChecker
 t1 = datetime(2016, 4, 28, 20, 0, 0, 0, UTC)
 # noinspection PyTypeChecker
@@ -63,7 +64,7 @@ class MqttClient(object):
         self.client.on_connect = self.on_connect
         self.client.on_message = self.on_message
 
-        self.client.connect("127.0.0.1", 1883, 60)
+        self.client.connect(mqtt_ip, 1883, 60)
         # Blocking call that processes network traffic, dispatches callbacks and
         # handles reconnecting.
         # Other loop*() functions are available that give a threaded interface and a

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -1,16 +1,16 @@
 # The MIT License (MIT)
 # Copyright (c) 2014-2017 University of Bristol
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -39,13 +39,13 @@ class HyperStreamLoggingTests(unittest.TestCase):
         $ docker run -ti -p 1883:1883 -p 9001:9001 toke/mosquitto
         or
         $ brew services start mosquitto
-        
+
         """
         # assert(mosquitto_is_running())
         logging.raiseExceptions = True
 
         # noinspection PyTypeChecker
-        mqtt_logger = dict(host="127.0.0.1", port=1883, topic="topics/test", loglevel=MON, qos=1)
+        mqtt_logger = dict(host=mqtt_ip, port=1883, topic="topics/test", loglevel=MON, qos=1)
 
         with HyperStream(file_logger=False, console_logger=False, mqtt_logger=mqtt_logger):
             with MqttClient() as client:
@@ -73,7 +73,7 @@ class HyperStreamLoggingTests(unittest.TestCase):
         mqtthandler.MQTTHandler.handleError = handleError
 
         # noinspection PyTypeChecker
-        mqtt_logger = dict(host="127.0.0.1", port=1883, topic="topics/test", loglevel=MON, qos=1,
+        mqtt_logger = dict(host=mqtt_ip, port=1883, topic="topics/test", loglevel=MON, qos=1,
                            formatter=SenMLFormatter())
 
         hs = HyperStream(file_logger=False, console_logger=False, mqtt_logger=mqtt_logger)


### PR DESCRIPTION
MQTT IP is now a variable in the tests so that it can be easily changed with `sed` if necessary:
```
sed -i -e 's/mqtt_ip = "127.0.0.1"/mqtt_ip = "hyperstream-mqtt"/g' tests/helpers.py
```
(this works perfectly for the Docker containers).