### PR TITLE
Added conditional switch between udatetime and datetime for Windows.

### DIFF
--- a/hyperstream/utils/time_utils.py
+++ b/hyperstream/utils/time_utils.py
@@ -20,7 +20,11 @@
 import json
 import pytz
 from datetime import datetime, date, timedelta
-import udatetime
+import os
+if os.name != 'nt':
+    import udatetime
+else:
+    from datetime import datetime as udatetime
 
 
 # noinspection PyClassHasNoInit

--- a/hyperstream/utils/time_utils.py
+++ b/hyperstream/utils/time_utils.py
@@ -24,7 +24,7 @@ import os
 if os.name != 'nt':
     import udatetime
 else:
-    from datetime import datetime as udatetime
+    udatetime = datetime
 
 
 # noinspection PyClassHasNoInit


### PR DESCRIPTION
Following the gitter discussion, simply added a conditional import "datetime as udatetime" for windows usage, tested with tutorial 1 and 5 on Windows 10 X64.